### PR TITLE
Foundation Grid Doesn't Compile

### DIFF
--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -3,10 +3,8 @@ $rem-base: 16px !default;
 
 $modules: () !default;
 @mixin exports($name) {
-  @if (index($modules, $name) == false) {
     $modules: append($modules, $name);
     @content;
-  }
 }
 
 //


### PR DESCRIPTION
## Description
Issue compiling foundation grid and other SASS mixins after update to webpack

