### PR TITLE
React 0.13 compatibility

### DIFF
--- a/dist/validation.js
+++ b/dist/validation.js
@@ -1,7 +1,7 @@
 /* jshint globalstrict: true */
 'use strict';
 
-var React = require('react');
+var React = require('react/addons');
 var classSet = require('react/lib/cx');
 var SynfrastructureHelperMixin = require('../mixins/synfrastructure-helper-mixin');
 
@@ -63,7 +63,7 @@ module.exports = React.createClass({
         var messages = this.renderValidationMessages(),
             orderdChildren = [];
 
-        orderdChildren = [{ 'message-children': this.props.children }, { 'message': messages }];
+        orderdChildren = [React.addons.createFragment({ 'message-children': this.props.children }), React.addons.createFragment({ 'message': messages })];
 
         if (this.props.renderMessages === 'before') {
             return orderdChildren.reverse();

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
          "css-loader"          : "0.9.1",
          "express-http-proxy"  : "0.4.0",
          "html-webpack-plugin" : "1.1.0",
-         "react"               : "0.12.2",
+         "react"               : "0.13.3",
          "react-hot-loader"    : "1.1.4",
          "request"             : "2.53.0",
          "sass-loader"         : "0.4.2",

--- a/src/validation.jsx
+++ b/src/validation.jsx
@@ -1,7 +1,7 @@
 /* jshint globalstrict: true */
 'use strict';
 
-var React                      = require('react');
+var React                      = require('react/addons');
 var classSet                   = require('react/lib/cx');
 var SynfrastructureHelperMixin = require('../mixins/synfrastructure-helper-mixin');
 
@@ -80,8 +80,8 @@ module.exports = React.createClass({
             orderdChildren = [];
 
         orderdChildren = [
-            {'message-children' : this.props.children},
-            {'message'          : messages}
+            React.addons.createFragment({'message-children' : this.props.children}),
+            React.addons.createFragment({'message'          : messages})
         ];
 
         if (this.props.renderMessages === 'before') {


### PR DESCRIPTION
In order to support React 0.13, arrays of child components must have the objects wrapped in `React.addons.createFragment`.

### AC

- Components work as before

### Tasks

- [x] Update synfrastructure to React 0.13
- [x] Update UIValidation component to look like:
```
orderdChildren = [
            React.addons.createFragment({'message-children' : this.props.children}),
            React.addons.createFragment({'message'          : messages})
        ];
```
- [x] Check for other instances of this pattern