### PR TITLE
Fix custom selects

### DIFF
--- a/dist/select.js
+++ b/dist/select.js
@@ -20,6 +20,7 @@ module.exports = React.createClass({
             selected: React.PropTypes.bool
         })).isRequired,
         componentCSSClassName: React.PropTypes.string,
+        componentWrapCSSClassName: React.PropTypes.string,
         customIcon: React.PropTypes.any,
         value: React.PropTypes.any,
         onFocus: React.PropTypes.func,
@@ -81,17 +82,21 @@ module.exports = React.createClass({
     },
 
     renderCustomSelect: function renderCustomSelect() {
+        var classes;
+
         if (!this.props.customIcon) {
             return this.renderDefaultSelect();
         }
 
+        classes = ['select--custom--wrap', this.props.componentWrapCSSClassName].join(' ');
+
         return React.createElement(
             'div',
-            { className: 'select__custom--wrap' },
+            { className: classes },
             this.renderDefaultSelect(),
             React.createElement(
                 'span',
-                { className: 'select__custom--icon' },
+                { className: 'select--custom--icon' },
                 this.props.customIcon
             )
         );
@@ -100,7 +105,7 @@ module.exports = React.createClass({
     renderDefaultSelect: function renderDefaultSelect() {
         var classes, customSelect;
 
-        customSelect = this.props.customIcon ? this.props.componentCSSClassName + '__custom' : null;
+        customSelect = this.props.customIcon ? this.props.componentCSSClassName + '--custom' : null;
 
         classes = [this.props.componentCSSClassName, this.props.className, customSelect].join(' ');
 

--- a/scss/components/_inputs.scss
+++ b/scss/components/_inputs.scss
@@ -315,7 +315,7 @@ $form-input-select-normalize     : false                                        
         margin-bottom  : 0;
         padding-right  : $form-input-select-padding-value * 2;
         padding-left   : $form-input-select-padding-value;
-        overflow-x     : hidden;
+        overflow       : hidden;
         background     : transparent !important;
 
         @include form-input-normalize;

--- a/scss/components/_inputs.scss
+++ b/scss/components/_inputs.scss
@@ -300,7 +300,7 @@ $form-input-select-normalize     : false                                        
     // 3. Custom Icon
 
     /* 1 */
-    .select__custom--wrap {
+    .select--custom--wrap {
         position      : relative;
         overflow      : hidden;
         margin        : $form-input-margin;
@@ -308,7 +308,7 @@ $form-input-select-normalize     : false                                        
     }
 
     /* 2 */
-    .select__custom {
+    .select--custom {
         position       : relative;
             z-index    : 2;
         width          : 100%;
@@ -329,7 +329,7 @@ $form-input-select-normalize     : false                                        
     }
 
     /* 3 */
-    .select__custom--icon {
+    .select--custom--icon {
         position    : absolute;
             top     : 50%;
             right   : $form-input-select-padding-value;

--- a/scss/components/_inputs.scss
+++ b/scss/components/_inputs.scss
@@ -313,11 +313,9 @@ $form-input-select-normalize     : false                                        
             z-index    : 2;
         width          : 100%;
         margin-bottom  : 0;
-        padding-top    : $form-input-select-padding-value / 2;
         padding-right  : $form-input-select-padding-value * 2;
-        padding-bottom : $form-input-select-padding-value / 2;
         padding-left   : $form-input-select-padding-value;
-        overflow       : hidden;
+        overflow-x     : hidden;
         background     : transparent !important;
 
         @include form-input-normalize;

--- a/scss/components/_inputs.scss
+++ b/scss/components/_inputs.scss
@@ -290,7 +290,7 @@ $form-input-select-normalize     : false                                        
     // 1. prevent text clipping
     .select {
         padding    : $form-input-select-padding;
-        background : shade($white, 5%);
+        background : shade($form-input-bg, 5%);
     }
 
     // Custom Select Component
@@ -304,7 +304,7 @@ $form-input-select-normalize     : false                                        
         position      : relative;
         overflow      : hidden;
         margin        : $form-input-margin;
-        background    : $white;
+        background    : $form-input-bg;
     }
 
     /* 2 */

--- a/src/select.jsx
+++ b/src/select.jsx
@@ -23,16 +23,17 @@ module.exports = React.createClass({
                 selected : React.PropTypes.bool
             })
         ).isRequired,
-        componentCSSClassName : React.PropTypes.string,
-        customIcon            : React.PropTypes.any,
-        value                 : React.PropTypes.any,
-        onFocus               : React.PropTypes.func,
-        onBlur                : React.PropTypes.func,
-        onChange              : React.PropTypes.func,
-        onKeyDown             : React.PropTypes.func,
-        onKeyUp               : React.PropTypes.func,
-        onKeyPress            : React.PropTypes.func,
-        className             : React.PropTypes.string
+        componentCSSClassName     : React.PropTypes.string,
+        componentWrapCSSClassName : React.PropTypes.string,
+        customIcon                : React.PropTypes.any,
+        value                     : React.PropTypes.any,
+        onFocus                   : React.PropTypes.func,
+        onBlur                    : React.PropTypes.func,
+        onChange                  : React.PropTypes.func,
+        onKeyDown                 : React.PropTypes.func,
+        onKeyUp                   : React.PropTypes.func,
+        onKeyPress                : React.PropTypes.func,
+        className                 : React.PropTypes.string
     },
 
     getDefaultProps : function()
@@ -89,12 +90,19 @@ module.exports = React.createClass({
 
     renderCustomSelect : function()
     {
+        var classes;
+
         if (! this.props.customIcon) {
             return this.renderDefaultSelect();
         }
 
+        classes = [
+            'select--custom--wrap',
+            this.props.componentWrapCSSClassName
+        ].join(' ');
+
         return (
-            <div className='select--custom--wrap'>
+            <div className={classes}>
                 {this.renderDefaultSelect()}
                 <span className='select--custom--icon'>
                     {this.props.customIcon}

--- a/src/select.jsx
+++ b/src/select.jsx
@@ -94,9 +94,9 @@ module.exports = React.createClass({
         }
 
         return (
-            <div className='select__custom--wrap'>
+            <div className='select--custom--wrap'>
                 {this.renderDefaultSelect()}
-                <span className='select__custom--icon'>
+                <span className='select--custom--icon'>
                     {this.props.customIcon}
                 </span>
             </div>
@@ -109,7 +109,7 @@ module.exports = React.createClass({
             customSelect;
 
         customSelect = (this.props.customIcon) ?
-            this.props.componentCSSClassName + '__custom' : null;
+            this.props.componentCSSClassName + '--custom' : null;
 
         classes = [
             this.props.componentCSSClassName,


### PR DESCRIPTION
- [x] The ui-inputs mixin has `$white` hardcoded into the custom select CSS output. This need to be changed to `$form-input-bg`. 
- [x] .select__custom should be changed to .select--custom
- [x] add a way to pass classNames to custom select wrapper
- [x] We also need to take top and bottom padding out of the custom select input